### PR TITLE
Fix a bug that api_key.txt file can not be read in shiny server

### DIFF
--- a/R/fct_helpers.R
+++ b/R/fct_helpers.R
@@ -524,8 +524,8 @@ validate_api_key <- function(api_key) {
 api_key_global <- Sys.getenv("OPEN_API_KEY")
 key_source <- "from OS environment variable."
 # If there is an key file in the current folder, use that instead.
-if (file.exists("api_key.txt")) {
-  api_key_file <- readLines("api_key.txt")
+if (file.exists(file.path(getwd(), "api_key.txt"))) {
+  api_key_file <- readLines(file.path(getwd(), "api_key.txt"))
   api_key <- clean_api_key(api_key_file)
 
   # if valid, replace with file


### PR DESCRIPTION
Hello Steven Ge, 

I think this project is AMAZING. So I installed the R package as instructed and installed the R package and ran it in RStudio.
I then attempted to deploy it on the shiny server.

I put the API text file into the working directory and set the API string in the environment. 
But the API key cannot be read by the RTutor. Everything I attempted didn't work.
As a result, I thought something might be wrong with the R code.

To enable the shiny server to read the content, I changed the path where it opened. 
This is a small patch, but I hope I can contribute a little. 
