### PR TITLE
Bug Fix: base R plots rendering blank in main panel

### DIFF
--- a/R/mod_04_main_panel.R
+++ b/R/mod_04_main_panel.R
@@ -725,8 +725,11 @@ mod_04_main_panel_serv <- function(id, llm_response, logs, ch, code_error,
       req(!code_error())
       req(logs$code)
       req(!is.null(run_result()$result) || !is.null(run_result()$console_output))
-      # Check if the result is not a ggplot or a known plot type
-      if (inherits(run_result()$result, "ggplot") || is.null(run_result()$console_output)) {
+      # ggplot: return object so print.ggplot draws it.
+      # Everything else (base R hist/plot, lattice, corrplot, etc.): re-evaluate
+      # so the plot is drawn as a side-effect — returning an invisible result
+      # (e.g. the histogram list from hist()) draws nothing.
+      if (inherits(run_result()$result, "ggplot")) {
         return(run_result()$result)
       } else {
         # If the result is not a ggplot (e.g., corrplot), re-evaluate the command_string,


### PR DESCRIPTION
- renderPlot was routing base R side-effect plots (hist, plot, barplot, corrplot, etc.) through the `return(result)` path because their console_output is NULL — but these functions return invisibly, so returning that value draws nothing.
- Removing the `|| is.null(console_output)` condition sends all non-ggplot results through the re-evaluation path, which draws them as side effects into the open graphics device.
- ggplot and all text/table output paths are unaffected.