### PR TITLE
Fix base R, lattice, and plotly rendering in main panel

### DIFF
--- a/R/mod_04_main_panel.R
+++ b/R/mod_04_main_panel.R
@@ -724,23 +724,24 @@ mod_04_main_panel_serv <- function(id, llm_response, logs, ch, code_error,
     output$result_plot <- renderPlot({
       req(!code_error())
       req(logs$code)
-      req(!is.null(run_result()$result) || !is.null(run_result()$console_output))
       # ggplot: return object so print.ggplot draws it.
       # Everything else (base R hist/plot, lattice, corrplot, etc.): re-evaluate
       # so the plot is drawn as a side-effect — returning an invisible result
       # (e.g. the histogram list from hist()) draws nothing.
       if (inherits(run_result()$result, "ggplot")) {
         return(run_result()$result)
-      } else {
-        # If the result is not a ggplot (e.g., corrplot), re-evaluate the command_string,
-        # under the parent environment of the run_env()
-        tmp_env <- list2env(run_env_start())
-        tryCatch({
-          eval_result <- eval(
-            parse(text = clean_cmd(logs$code, selected_dataset_name(), file.exists(on_server))),
-            envir = tmp_env
-          )
-        })
+      } else if (!inherits(run_result()$result, "htmlwidget")) {
+        # Re-evaluate so side-effect plots (hist, corrplot, etc.) draw into the
+        # Shiny device, and visible-return plots (lattice trellis) get auto-printed.
+        # Use run_env()'s parent so the search path (ggplot2 data, etc.) is reachable.
+        # htmlwidgets (plotly, etc.) are excluded — renderPlotly handles them, and
+        # calling print() on a widget opens a browser tab instead of drawing here.
+        tmp_env <- list2env(run_env_start(), parent = parent.env(run_env()))
+        parsed  <- parse(text = clean_cmd(logs$code, selected_dataset_name(), file.exists(on_server)))
+        for (expr in parsed) {
+          vis <- withVisible(eval(expr, envir = tmp_env))
+          if (vis$visible && !inherits(vis$value, "htmlwidget")) print(vis$value)
+        }
       }
     })
 

--- a/R/mod_07_run_code.R
+++ b/R/mod_07_run_code.R
@@ -106,7 +106,7 @@ mod_07_run_code_serv <- function(id, run_env, run_env_start, run_result, submit_
             for (i in seq_along(parsed_exprs)) {
               vis        <- withVisible(eval(parsed_exprs[[i]], envir = run_env()))
               eval_result <- vis$value
-              if (vis$visible) print(vis$value)
+              if (vis$visible && !inherits(vis$value, "htmlwidget")) print(vis$value)
             }
           })
 


### PR DESCRIPTION
  1. Base R side-effect plots (hist, corrplot, etc.) were blank because renderPlot returned the invisible result value instead of re-evaluating the code to draw into the Shiny device.

  2. Lattice and other visible-return plot types (trellis) were blank because re-evaluation used eval() without auto-printing visible results. Fixed by using a withVisible loop mirroring mod_07's execution path, and giving tmp_env the correct parent chain so package data is reachable.

  3. plotly and other htmlwidgets opened browser tabs because print() was called on them in both mod_07 (inside capture.output, which does not suppress browseURL) and in mod_04's re-evaluation loop. Fixed by skipping print() for htmlwidget objects in both loops; the widget object is still captured via eval_result and rendered by renderPlotly.

  Also removed a req() in renderPlot that incorrectly blocked rendering
  when both result and console_output were NULL — a valid state for
  multi-expression plots where the last call is a side-effect (e.g. lines()).